### PR TITLE
Add back reportlab dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -6425,4 +6425,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9.13,<4.0"
-content-hash = "1b15c1c98ee43cc9530efffe048ac444f054c9651b908a8dd06deb888d1695ef"
+content-hash = "1b0f5495134a5ff10a9cbd387a01255b9a9f875b9370c5971ad7809c3c1df137"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,8 @@ dependencies = [
     "pymupdf (>=1.26.0,<2.0.0)",
     "paddlepaddle (>=3.0.0,<4.0.0)",
     "easyocr (>=1.7.2,<2.0.0)",
-    "sentence-transformers (>=4.1.0,<5.0.0)"
+    "sentence-transformers (>=4.1.0,<5.0.0)",
+    "reportlab (>=4.4.1,<5.0.0)"
 ]
 
 


### PR DESCRIPTION
This was being removed since the conflict. Adding back to make sure everything OK.